### PR TITLE
feature/using git tags for versioning

### DIFF
--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,5 +1,16 @@
 #!/bin/bash -eux
 
+
 pushd dis-design-system-go
   make build
+  TAG=`git tag --points-at HEAD | grep ^v | head -n 1`
+  
+  if [ -z "${TAG}" ]; then
+    echo "No tag found, using short commit hash"
+    TAG=`git rev-parse --short HEAD`
+  fi
+
 popd
+
+mkdir build/$TAG
+cp -a dis-design-system-go/dist/assets/. build/$TAG


### PR DESCRIPTION
### What

Updated `ci/scripts/build.sh` to use the git tag (version) if present as the directory where built files are stored in CI which are then uploaded into the s3 cdn bucket

### How to review

Sense check

### Who can review

!me
