### PR TITLE
Exclude audit-node from depenabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: make audit-go
   
   audit-node:
+    # Dependabot PRs cannot access secrets so the node audit check will be skipped for those PRs.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
### What

JS audit checks require auth which dependabot does not have - skip the PR check for those ones. As dependabot is currently only looking at github actions, this is acceptable. 

### How to review

Check looks ok - matches dis-redirect-api 

### Who can review

Not me. 